### PR TITLE
Added Replace Method

### DIFF
--- a/DbRegex/Regex.cs
+++ b/DbRegex/Regex.cs
@@ -9,4 +9,11 @@ public partial class UserDefinedFunctions
         var match = RX.Regex.Match(input, regex).Groups[1].Value;
         return new SqlString (match);
     }
+
+    [Microsoft.SqlServer.Server.SqlFunction]
+    public static SqlString RegexReplace(string input, string regex, string replacement)
+    {
+        var result = RX.Regex.Replace(input, regex, replacement);
+        return new SqlString(result);
+    }
 }


### PR DESCRIPTION
One of the most common use cases for Regex is the replace method, which is a convenient shorthand for replacing a subtring in a given string by evaluating a regular expression.  I have added a function to the Regex.cs module which is a wrapper for the C# Regex.Replace function.  It can be used in SQL Server as below:

CREATE FUNCTION.[dbo].[regexreplace] (@text [nvarchar](MAX), @regex [nvarchar](MAX),@replacement [nvarchar](MAX))
RETURNS [nvarchar](MAX)
AS EXTERNAL NAME [DbRegex].[UserDefinedFunctions].[RegexReplace]

select dbo.regexreplace('1234abc (test)','\s\([A-Za-z]+\)','')

returns '1234abc'
